### PR TITLE
add pandas 0.20.1; update sort method

### DIFF
--- a/graphitty/graphitty.py
+++ b/graphitty/graphitty.py
@@ -104,7 +104,7 @@ class Graphitty(object):
         """
         if not add_edge_callback:
             add_edge_callback = self.add_edge_callback
-        sorted_time = group.sort(self.ts_col)
+        sorted_time = group.sort_values(self.ts_col)
         seen_templates = {}
         path = ['start']
         for _, row in sorted_time.iterrows():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 nxpd==0.1.2
-pandas==0.16.0
+pandas==0.20.1
 
 # test requirements
 tox


### PR DESCRIPTION
# What Changed

+ `pandas` 0.20.1 appears to have broken the `DataFrame.sort` method.
+ Updated to `pandas==0.20.1` and replaced the deprecated `sort` method with `sort_values`.

## How To Test Drive

`py.test --pep8`